### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 MCP tool for Google search and webpage content extraction using Chrome browser. Works with Claude to enable Google search and content fetching capabilities.
 
+<a href="https://glama.ai/mcp/servers/qomavmghwi"><img width="380" height="200" src="https://glama.ai/mcp/servers/qomavmghwi/badge" alt="Chrome Google Search MCP server" /></a>
+
 ## Quick Installation
 
 1. **Configure Claude Desktop**


### PR DESCRIPTION
This PR adds a badge for the [MCP Chrome Google Search](https://glama.ai/mcp/servers/qomavmghwi) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/qomavmghwi"><img width="380" height="200" src="https://glama.ai/mcp/servers/qomavmghwi/badge" alt="Chrome Google Search MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.